### PR TITLE
fix layout memory leak

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -17,7 +17,7 @@ angular.module('ui.layout', [])
     // regex to verify size is properly set to pixels or percent
     var sizePattern = /\d+\s*(px|%)\s*$/i;
 
-    Layout.addLayout(ctrl);
+    var unsubscribeLayout = Layout.addLayout(ctrl);
 
     ctrl.containers = [];
     ctrl.movingSplitbar = null;
@@ -652,6 +652,10 @@ angular.module('ui.layout', [])
       return -1;
     };
 
+    ctrl.destroy = function() {
+      unsubscribeLayout();
+    };
+
     return ctrl;
   }])
 
@@ -679,6 +683,7 @@ angular.module('ui.layout', [])
 
         scope.$on('$destroy', function() {
           angular.element($window).unbind('resize', onResize);
+          ctrl.destroy();
         });
       }
     };
@@ -1023,7 +1028,8 @@ angular.module('ui.layout', [])
     var layouts = [],
       collapsing = [],
       toBeCollapsed = 0,
-      toggledDeffered =  null;
+      toggledDeffered =  null,
+      layoutId = 0;
 
     function toggleContainer(container) {
       try {
@@ -1036,8 +1042,12 @@ angular.module('ui.layout', [])
 
     return {
       addLayout: function (ctrl) {
-        ctrl.id = layouts.length;
+        ctrl.id = layoutId++;
         layouts.push(ctrl);
+
+        return function() {
+          layouts.splice(layouts.indexOf(ctrl), 1);
+        }
       },
       addCollapsed: function(container) {
         collapsing.push(container);

--- a/test/uiLayoutCtrl.spec.js
+++ b/test/uiLayoutCtrl.spec.js
@@ -2,14 +2,16 @@
 
 
 describe('Controller: uiLayoutCtrl', function () {
-  var scope, $controller;
+  var scope, $controller, Layout;
+
   beforeEach(function () {
 
     module('ui.layout');
 
-    inject(function ($rootScope, _$controller_) {
+    inject(function ($rootScope, _$controller_, _Layout_) {
       scope = $rootScope.$new();
       $controller = _$controller_;
+      Layout = _Layout_;
     });
   });
 
@@ -35,6 +37,28 @@ describe('Controller: uiLayoutCtrl', function () {
       expect(uic.isLayoutElement(attrSplitbar)).toEqual(true);
       expect(uic.isLayoutElement(tagContainer)).toEqual(true);
       expect(uic.isLayoutElement(notUiEl)).toEqual(false);
+    });
+
+    it('destroy should call the unsubscribe function returned by Layout.addLayout', function () {
+      var unsubscribeLayout = jasmine.createSpy('unsubscribeLayout');
+
+      spyOn(Layout, 'addLayout');
+      Layout.addLayout.and.callFake(function(){
+        return unsubscribeLayout;
+      });
+
+      var uic = $controller('uiLayoutCtrl', {
+        $scope: scope,
+        $attrs: {},
+        $element: angular.element('<div></div>')
+      });
+
+      expect(Layout.addLayout).toHaveBeenCalledWith(uic);
+      expect(unsubscribeLayout).not.toHaveBeenCalled();
+
+      uic.destroy();
+
+      expect(unsubscribeLayout).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
(cherry picked from commit 1db8fd2e2d09f12d73d66ee50cd62c557a06c37e)

The `Layout` service has a significant memory leak.  There's an open [issue](https://github.com/angular-ui/ui-layout/issues/175) to address it, but there has been no activity for 2 year.  I found a small [PR](https://github.com/angular-ui/ui-layout/pull/230/commits/1db8fd2e2d09f12d73d66ee50cd62c557a06c37e) that had a minimal set of changes to address this issue so I cherry-picked it.